### PR TITLE
Fix Lua header include directives in tolua++.h

### DIFF
--- a/include/tolua++.h
+++ b/include/tolua++.h
@@ -43,8 +43,8 @@ extern "C" {
 
 typedef int lua_Object;
 
-#include "lua.h"
-#include "lauxlib.h"
+#include <lua.h>
+#include <lauxlib.h>
 
 struct tolua_Error
 {


### PR DESCRIPTION
Use angle bracket rather than double quotes when including Lua headers in the tolua++ header. This fixes a problem on systems that default to a Lua version newer than 5.1 and install the tolua++ header to the same directory as newer Lua headers.

As there are (usually) no Lua headers in the same directory when building tolua++ itself, the preprocessor will look to the include directories passed to the compiler, one of which would be the Lua 5.1 include directory, and tolua++ will build with those (correct) headers. Then the tolua++ header is usually installed in the default include directory, alongside the newer Lua headers, which you wouldn't expect to cause any trouble.

But it does cause trouble when trying to build other programs that include the tolua++ header, because now the preprocessor does find Lua headers in the same directory as the tolua++ header, which are the newer (incorrect) headers. Now the program will either fail to compile, because it doesn't support the newer headers, or fail to link with the tolua++ shared object because they were compiled against different Lua headers.

Using angle brackets instead of double quotes in the include directives will fix the problem, because then the preprocessor will look to the include directories passed to the compiler first.

See http://www.cegui.org.uk/forum/viewtopic.php?f=10&t=7195